### PR TITLE
Added SavedStateHandle to avoid unnecessary repository call

### DIFF
--- a/app/src/main/java/com/example/rickandmorty/ui/characterdetail/CharacterDetailFragment.kt
+++ b/app/src/main/java/com/example/rickandmorty/ui/characterdetail/CharacterDetailFragment.kt
@@ -32,7 +32,6 @@ class CharacterDetailFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        arguments?.getInt("id")?.let { viewModel.start(it) }
         setupObservers()
     }
 

--- a/app/src/main/java/com/example/rickandmorty/ui/characterdetail/CharacterDetailViewModel.kt
+++ b/app/src/main/java/com/example/rickandmorty/ui/characterdetail/CharacterDetailViewModel.kt
@@ -1,28 +1,21 @@
 package com.example.rickandmorty.ui.characterdetail
 
+import androidx.hilt.Assisted
 import androidx.hilt.lifecycle.ViewModelInject
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.switchMap
+import androidx.lifecycle.*
 import com.example.rickandmorty.data.entities.Character
 import com.example.rickandmorty.data.repository.CharacterRepository
 import com.example.rickandmorty.utils.Resource
+import java.lang.Exception
 
 class CharacterDetailViewModel @ViewModelInject constructor(
-    private val repository: CharacterRepository
+    @Assisted private val savedStateHandle: SavedStateHandle,
+    repository: CharacterRepository
 ) : ViewModel() {
 
-    private val _id = MutableLiveData<Int>()
-
-    private val _character = _id.switchMap { id ->
-        repository.getCharacter(id)
-    }
-    val character: LiveData<Resource<Character>> = _character
-
-
-    fun start(id: Int) {
-        _id.value = id
-    }
-
+    val character: LiveData<Resource<Character>> =
+        repository.getCharacter(
+            savedStateHandle.get<Int>("id")
+                ?: throw Exception("You need to pass character id")
+        )
 }


### PR DESCRIPTION
onViewCreated can be called multiple times on fragment lifecycle ( orientation changes ) so this would be cause multiple repository call and unnecessary view changes. SavedStateHandle helps us like this scenarios.